### PR TITLE
chore(deps): Bump mvdan.cc/sh/v3 from 3.6.1-0.20221221181323-d3feb15bed3a to 3.7.0

### DIFF
--- a/e2e/env/regressions.go
+++ b/e2e/env/regressions.go
@@ -127,11 +127,11 @@ func (c ctx) issue43(t *testing.T) {
 }
 
 // https://github.com/sylabs/singularity/issues/1263
-// With --env-file we should avoid any override of UID / GID / EUID that are set readonly by bash.
+// With --env-file we should avoid any override of EUID/UID/GID that are set readonly by bash.
 func (c ctx) issue1263(t *testing.T) {
 	e2e.EnsureImage(t, c.env)
 
-	// An empty env file is sufficient, as UID/GID/EUID come from the mvdan.cc/sh evaluation of it.
+	// An empty env file is sufficient, as EUID/UID/GID come from the mvdan.cc/sh evaluation of it.
 	envFile, err := e2e.WriteTempFile(c.env.TestDir, "env-file", "")
 	if err != nil {
 		t.Fatal(err)

--- a/go.mod
+++ b/go.mod
@@ -59,7 +59,7 @@ require (
 	golang.org/x/text v0.11.0
 	gopkg.in/yaml.v3 v3.0.1
 	gotest.tools/v3 v3.5.0
-	mvdan.cc/sh/v3 v3.6.1-0.20221221181323-d3feb15bed3a
+	mvdan.cc/sh/v3 v3.7.0
 	oras.land/oras-go v1.2.3
 )
 

--- a/go.sum
+++ b/go.sum
@@ -480,7 +480,7 @@ github.com/felixge/httpsnoop v1.0.3/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSw
 github.com/flynn/go-shlex v0.0.0-20150515145356-3f9db97f8568/go.mod h1:xEzjJPgXI435gkrCt3MPfRiAkVrwSbHsst4LCFVfpJc=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/frankban/quicktest v1.11.3/go.mod h1:wRf/ReqHper53s+kmmSZizM8NamnL3IM0I9ntUbOk+k=
-github.com/frankban/quicktest v1.14.4 h1:g2rn0vABPOOXmZUj+vbmUp0lPoXEMuhTpIluN0XL9UY=
+github.com/frankban/quicktest v1.14.5 h1:dfYrrRyLtiqT9GyKXgdh+k4inNeTvmGbuSgZ3lx3GhA=
 github.com/fsnotify/fsnotify v1.4.7/go.mod h1:jwhsz4b93w/PPRr/qN1Yymfu8t87LnFCMoQvtojpjFo=
 github.com/fsnotify/fsnotify v1.4.9/go.mod h1:znqG4EE+3YCdAaPaxE2ZRY/06pZUdp0tY4IgpuI1SZQ=
 github.com/fsnotify/fsnotify v1.5.1/go.mod h1:T3375wBYaZdLLcVNkcVbzGHY7f1l/uK5T5Ai1i3InKU=
@@ -1104,7 +1104,7 @@ github.com/rogpeppe/fastuuid v1.2.0/go.mod h1:jVj6XXZzXRy/MSR5jhDC/2q6DgLz+nrA6L
 github.com/rogpeppe/go-internal v1.1.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.2.2/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
-github.com/rogpeppe/go-internal v1.9.0 h1:73kH8U+JUqXU8lRuOHeVHaa/SZPifC7BkcraZVejAe8=
+github.com/rogpeppe/go-internal v1.10.1-0.20230524175051-ec119421bb97 h1:3RPlVWzZ/PDqmVuf/FKHARG5EMid/tl7cv54Sw/QRVY=
 github.com/rootless-containers/proto v0.1.0 h1:gS1JOMEtk1YDYHCzBAf/url+olMJbac7MTrgSeP6zh4=
 github.com/rootless-containers/proto v0.1.0/go.mod h1:vgkUFZbQd0gcE/K/ZwtE4MYjZPu0UNHLXIQxhyqAFh8=
 github.com/russross/blackfriday v1.6.0/go.mod h1:ti0ldHuxg49ri4ksnFxlkCfN+hvslNlmVHqNRXXJNAY=
@@ -2017,8 +2017,8 @@ k8s.io/kube-openapi v0.0.0-20200805222855-6aeccd4b50c6/go.mod h1:UuqjUnNftUyPE5H
 k8s.io/kube-openapi v0.0.0-20201113171705-d219536bb9fd/go.mod h1:WOJ3KddDSol4tAGcJo0Tvi+dK12EcqSLqcWsryKMpfM=
 k8s.io/kubernetes v1.13.0/go.mod h1:ocZa8+6APFNC2tX1DZASIbocyYT5jHzqFVsY5aoB7Jk=
 k8s.io/utils v0.0.0-20201110183641-67b214c5f920/go.mod h1:jPW/WVKK9YHAvNhRxK0md/EJ228hCsBRufyofKtW8HA=
-mvdan.cc/sh/v3 v3.6.1-0.20221221181323-d3feb15bed3a h1:AK8d/j//vNToLhsO0B15DybhgHIQ27GbmvcTXv7S7VY=
-mvdan.cc/sh/v3 v3.6.1-0.20221221181323-d3feb15bed3a/go.mod h1:U4mhtBLZ32iWhif5/lD+ygy1zrgaQhUu+XFy7C8+TTA=
+mvdan.cc/sh/v3 v3.7.0 h1:lSTjdP/1xsddtaKfGg7Myu7DnlHItd3/M2tomOcNNBg=
+mvdan.cc/sh/v3 v3.7.0/go.mod h1:K2gwkaesF/D7av7Kxl0HbF5kGOd2ArupNTX3X44+8l8=
 rsc.io/binaryregexp v0.2.0/go.mod h1:qTv7/COck+e2FymRvadv62gMdZztPaShugOCi3I+8D8=
 rsc.io/quote/v3 v3.1.0/go.mod h1:yEA65RcK8LyAZtP9Kv3t0HmxON59tX3rD+tICJqUlj0=
 rsc.io/sampler v1.3.0/go.mod h1:T1hPZKmBbMNahiBKFy5HrXp6adAjACjK9JXDnKaTXpA=

--- a/internal/pkg/runtime/launcher/native/launcher_linux.go
+++ b/internal/pkg/runtime/launcher/native/launcher_linux.go
@@ -1014,7 +1014,7 @@ func (l *Launcher) setEnvVars(ctx context.Context, args []string) error {
 			return fmt.Errorf("could not read environment file %q: %w", l.cfg.EnvFile, err)
 		}
 
-		envvars, err := interpreter.EvaluateEnv(ctx, content, args, currentEnv)
+		shellEnv, err := interpreter.EvaluateEnv(ctx, content, args, currentEnv)
 		if err != nil {
 			return fmt.Errorf("while processing %s: %w", l.cfg.EnvFile, err)
 		}
@@ -1023,7 +1023,7 @@ func (l *Launcher) setEnvVars(ctx context.Context, args []string) error {
 		sylog.Debugf("Setting environment variables from file %s", l.cfg.EnvFile)
 
 		// Update Env with those from file
-		for _, envar := range envvars {
+		for _, envar := range shellEnv {
 			e := strings.SplitN(envar, "=", 2)
 			if len(e) != 2 {
 				sylog.Warningf("Ignored environment variable %q: '=' is missing", envar)
@@ -1031,7 +1031,7 @@ func (l *Launcher) setEnvVars(ctx context.Context, args []string) error {
 			}
 			// Don't attempt to overwrite bash builtin readonly vars
 			// https://github.com/sylabs/singularity/issues/1263
-			if e[0] == "UID" || e[0] == "GID" || e[0] == "EUID" {
+			if _, ok := env.ReadOnlyVars[e[0]]; ok {
 				continue
 			}
 			// Ensure we don't overwrite --env variables with environment file

--- a/internal/pkg/runtime/launcher/oci/process_linux.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux.go
@@ -348,23 +348,18 @@ func envFileMap(ctx context.Context, f string) (map[string]string, error) {
 
 	// Use the embedded shell interpreter to evaluate the env file, with an empty starting environment.
 	// Shell takes care of comments, quoting etc. for us and keeps compatibility with native runtime.
-	env, err := interpreter.EvaluateEnv(ctx, content, []string{}, []string{})
+	shellEnv, err := interpreter.EvaluateEnv(ctx, content, []string{}, []string{})
 	if err != nil {
 		return envMap, fmt.Errorf("while processing %s: %w", f, err)
 	}
 
-	for _, envVar := range env {
+	for _, envVar := range shellEnv {
 		parts := strings.SplitN(envVar, "=", 2)
 		if len(parts) < 2 {
 			continue
 		}
 		// Strip out the runtime env vars set by the shell interpreter
-		if parts[0] == "GID" ||
-			parts[0] == "HOME" ||
-			parts[0] == "IFS" ||
-			parts[0] == "OPTIND" ||
-			parts[0] == "PWD" ||
-			parts[0] == "UID" {
+		if _, ok := env.ReadOnlyVars[parts[0]]; ok {
 			continue
 		}
 		envMap[parts[0]] = parts[1]

--- a/internal/pkg/runtime/launcher/oci/process_linux_test.go
+++ b/internal/pkg/runtime/launcher/oci/process_linux_test.go
@@ -82,9 +82,7 @@ func TestEnvFileMap(t *testing.T) {
 		{
 			name:    "EmptyFile",
 			envFile: "",
-			want: map[string]string{
-				"EUID": "0",
-			},
+			want:    map[string]string{},
 			wantErr: false,
 		},
 		{
@@ -92,9 +90,8 @@ func TestEnvFileMap(t *testing.T) {
 			envFile: `FOO=BAR
 			ABC=123`,
 			want: map[string]string{
-				"EUID": "0",
-				"FOO":  "BAR",
-				"ABC":  "123",
+				"FOO": "BAR",
+				"ABC": "123",
 			},
 			wantErr: false,
 		},
@@ -102,8 +99,7 @@ func TestEnvFileMap(t *testing.T) {
 			name:    "DoubleQuote",
 			envFile: `FOO="FOO BAR"`,
 			want: map[string]string{
-				"EUID": "0",
-				"FOO":  "FOO BAR",
+				"FOO": "FOO BAR",
 			},
 			wantErr: false,
 		},
@@ -111,8 +107,7 @@ func TestEnvFileMap(t *testing.T) {
 			name:    "SingleQuote",
 			envFile: `FOO='FOO BAR'`,
 			want: map[string]string{
-				"EUID": "0",
-				"FOO":  "FOO BAR",
+				"FOO": "FOO BAR",
 			},
 			wantErr: false,
 		},
@@ -120,8 +115,7 @@ func TestEnvFileMap(t *testing.T) {
 			name:    "MultiLine",
 			envFile: "FOO=\"FOO\nBAR\"",
 			want: map[string]string{
-				"EUID": "0",
-				"FOO":  "FOO\nBAR",
+				"FOO": "FOO\nBAR",
 			},
 			wantErr: false,
 		},

--- a/internal/pkg/util/env/env.go
+++ b/internal/pkg/util/env/env.go
@@ -41,6 +41,16 @@ var ApptainerPrefixes = []string{ApptainerPrefix, LegacySingularityPrefix}
 // to container
 var ApptainerEnvPrefixes = []string{ApptainerEnvPrefix, LegacySingularityEnvPrefix}
 
+var ReadOnlyVars = map[string]bool{
+	"EUID":   true,
+	"GID":    true,
+	"HOME":   true,
+	"IFS":    true,
+	"OPTIND": true,
+	"PWD":    true,
+	"UID":    true,
+}
+
 // SetFromList sets environment variables from environ argument list.
 func SetFromList(environ []string) error {
 	for _, env := range environ {

--- a/internal/pkg/util/shell/interpreter/interpreter.go
+++ b/internal/pkg/util/shell/interpreter/interpreter.go
@@ -126,9 +126,10 @@ func New(r io.Reader, name string, args []string, envs []string, runnerOptions .
 		dir = "/"
 	}
 
+	// TODO - update to ExecHandlers, as ExecHandler is deprecated.
 	opts := []interp.RunnerOption{
 		interp.StdIO(os.Stdin, os.Stdout, os.Stderr),
-		interp.ExecHandler(s.internalExecHandler()),
+		interp.ExecHandler(s.internalExecHandler()), //nolint:staticcheck
 		interp.OpenHandler(s.internalOpenHandler()),
 		interp.Params("--"),
 		interp.Env(expand.ListEnviron(envs...)),
@@ -305,8 +306,9 @@ func EvaluateEnv(ctx context.Context, script []byte, args []string, envs []strin
 		return nil, fmt.Errorf("could not open/create/modify %q: file feature is disabled", path)
 	}
 
+	// TODO - update to ExecHandlers, as ExecHandler is deprecated.
 	opts := []interp.RunnerOption{
-		interp.ExecHandler(execHandler),
+		interp.ExecHandler(execHandler), //nolint:staticcheck
 		interp.OpenHandler(openHandler),
 		interp.Env(newNonExportedEnv(envs)),
 	}

--- a/internal/pkg/util/shell/interpreter/interpreter_test.go
+++ b/internal/pkg/util/shell/interpreter/interpreter_test.go
@@ -292,7 +292,7 @@ func TestEvaluateEnv(t *testing.T) {
 	}
 
 	// Since mvdan.cc/sh/v3@v3.4.0 some default vars will be set:
-	//    HOME IFS OPTIND PWD UID GID
+	//    HOME IFS OPTIND PWD UID GID EUID
 	// These don't adversely impact our downstream container environment, but
 	// must be accounted for here.
 	// https://github.com/mvdan/sh/commit/f4c774aa15046ef006508e182fde10c4b56876fa


### PR DESCRIPTION
This pulls in apptainer/apptainer# 1452 into the oci-action branch and adds one more oci-specific change from sylabs/singularity# 1789.  It's done as a separate PR here instead of waiting for a rebase so that extra oci change doesn't get forgotten.